### PR TITLE
Making the radio work without channel argument

### DIFF
--- a/src/channels.js
+++ b/src/channels.js
@@ -16,7 +16,7 @@ const channels = {
 export default {
   ...channels,
   active: channels.P3,
-  select(channelName) {
+  select(channelName = '') {
     this.active = this[channelName.toUpperCase()] || channels.P3;
   },
 };

--- a/test/channels.test.js
+++ b/test/channels.test.js
@@ -18,4 +18,8 @@ describe('channels.js', () => {
     channels.select('p1');
     expect(channels.active.name).toEqual('P1');
   });
+  it('select should default to P3 when not passing any channel argument', () => {
+    channels.select();
+    expect(channels.active.name).toEqual('P3');
+  });
 });


### PR DESCRIPTION
The radio did not previously work without passing a channel argument (i.e. just `sverigesradio`). This PR fixes this and defaults to the P3 channel.

Summary of changes:
- Making the radio work without channel argument

